### PR TITLE
Restore dynamic navigation items in header menus

### DIFF
--- a/snippets/header-drawer.liquid
+++ b/snippets/header-drawer.liquid
@@ -50,16 +50,7 @@
                             {{ link.title | escape }}
                           </button>
                           <ul class="menu-drawer__menu list-menu" role="list" tabindex="-1">
-                            {%- assign link_title_down = link.title | downcase | strip -%}
-                            {%- assign is_watch_parts = false -%}
-                            {%- if link_title_down == 'watch parts' -%}
-                              {%- assign is_watch_parts = true -%}
-                            {%- endif -%}
-                            {%- assign rendered_count = 0 -%}
                             {%- for childlink in link.links -%}
-                              {%- if is_watch_parts and rendered_count >= 5 -%}
-                                {%- continue -%}
-                              {%- endif -%}
                               <li>
                                 {%- if childlink.links == blank -%}
                                   <a
@@ -72,80 +63,58 @@
                                   >
                                     {{ childlink.title | escape }}
                                   </a>
-                                  {%- assign rendered_count = rendered_count | plus: 1 -%}
                                 {%- else -%}
-                                  {%- if is_watch_parts -%}
-                                    <a
-                                      id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}-flat"
-                                      href="{{ childlink.url }}"
+                                  <details id="Details-menu-drawer-{{ link.handle }}-{{ childlink.handle }}">
+                                    <summary
+                                      id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
                                       class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
                                     >
                                       {{ childlink.title | escape }}
-                                    </a>
-                                    {%- assign rendered_count = rendered_count | plus: 1 -%}
-                                  {%- else -%}
-                                    <details id="Details-menu-drawer-{{ link.handle }}-{{ childlink.handle }}">
-                                      <summary
-                                        id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}"
-                                        class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
+                                      <span class="svg-wrapper">
+                                        {{- 'icon-arrow.svg' | inline_asset_content -}}
+                                      </span>
+                                      <span class="svg-wrapper">
+                                        {{- 'icon-caret.svg' | inline_asset_content -}}
+                                      </span>
+                                    </summary>
+                                    <div
+                                      id="childlink-{{ childlink.handle | escape }}"
+                                      class="menu-drawer__submenu has-submenu gradient motion-reduce"
+                                    >
+                                      <button
+                                        class="menu-drawer__close-button link link--text focus-inset"
+                                        aria-expanded="true"
                                       >
-                                        {{ childlink.title | escape }}
                                         <span class="svg-wrapper">
                                           {{- 'icon-arrow.svg' | inline_asset_content -}}
                                         </span>
-                                        <span class="svg-wrapper">
-                                          {{- 'icon-caret.svg' | inline_asset_content -}}
-                                        </span>
-                                      </summary>
-                                      <div
-                                        id="childlink-{{ childlink.handle | escape }}"
-                                        class="menu-drawer__submenu has-submenu gradient motion-reduce"
+                                        {{ childlink.title | escape }}
+                                      </button>
+                                      <ul
+                                        class="menu-drawer__menu list-menu"
+                                        role="list"
+                                        tabindex="-1"
                                       >
-                                        <button
-                                          class="menu-drawer__close-button link link--text focus-inset"
-                                          aria-expanded="true"
-                                        >
-                                          <span class="svg-wrapper">
-                                            {{- 'icon-arrow.svg' | inline_asset_content -}}
-                                          </span>
-                                          {{ childlink.title | escape }}
-                                        </button>
-                                        <ul
-                                          class="menu-drawer__menu list-menu"
-                                          role="list"
-                                          tabindex="-1"
-                                        >
-                                          {%- for grandchildlink in childlink.links -%}
-                                            <li>
-                                              <a
-                                                id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
-                                                href="{{ grandchildlink.url }}"
-                                                class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if grandchildlink.current %} menu-drawer__menu-item--active{% endif %}"
-                                                {% if grandchildlink.current %}
-                                                  aria-current="page"
-                                                {% endif %}
-                                              >
-                                                {{ grandchildlink.title | escape }}
-                                              </a>
-                                            </li>
-                                          {%- endfor -%}
-                                        </ul>
-                                      </div>
-                                    </details>
-                                  {%- endif -%}
+                                        {%- for grandchildlink in childlink.links -%}
+                                          <li>
+                                            <a
+                                              id="HeaderDrawer-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                              href="{{ grandchildlink.url }}"
+                                              class="menu-drawer__menu-item link link--text list-menu__item focus-inset{% if grandchildlink.current %} menu-drawer__menu-item--active{% endif %}"
+                                              {% if grandchildlink.current %}
+                                                aria-current="page"
+                                              {% endif %}
+                                            >
+                                              {{ grandchildlink.title | escape }}
+                                            </a>
+                                          </li>
+                                        {%- endfor -%}
+                                      </ul>
+                                    </div>
+                                  </details>
                                 {%- endif -%}
                               </li>
                             {%- endfor -%}
-                            {%- if is_watch_parts and link.url != blank -%}
-                              <li>
-                                <a
-                                  href="{{ link.url }}"
-                                  class="menu-drawer__menu-item link link--text list-menu__item focus-inset"
-                                >
-                                  View all {{ link.title | escape }}
-                                </a>
-                              </li>
-                            {%- endif -%}
                           </ul>
                         </div>
                       </div>

--- a/snippets/header-dropdown-menu.liquid
+++ b/snippets/header-dropdown-menu.liquid
@@ -32,16 +32,7 @@
                 role="list"
                 tabindex="-1"
               >
-                {%- assign link_title_down = link.title | downcase | strip -%}
-                {%- assign is_watch_parts = false -%}
-                {%- if link_title_down == 'watch parts' -%}
-                  {%- assign is_watch_parts = true -%}
-                {%- endif -%}
-                {%- assign rendered_count = 0 -%}
                 {%- for childlink in link.links -%}
-                  {%- if is_watch_parts and rendered_count >= 5 -%}
-                    {%- continue -%}
-                  {%- endif -%}
                   <li>
                     {%- if childlink.links == blank -%}
                       <a
@@ -54,60 +45,38 @@
                       >
                         {{ childlink.title | escape }}
                       </a>
-                      {%- assign rendered_count = rendered_count | plus: 1 -%}
                     {%- else -%}
-                      {%- if is_watch_parts -%}
-                        <a
+                      <details id="Details-HeaderSubMenu-{{ link.handle }}-{{ childlink.handle }}">
+                        <summary
                           id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
-                          href="{{ childlink.url }}"
-                          class="header__menu-item list-menu__item link link--text focus-inset caption-large"
+                          class="header__menu-item link link--text list-menu__item focus-inset caption-large"
                         >
-                          {{ childlink.title | escape }}
-                        </a>
-                        {%- assign rendered_count = rendered_count | plus: 1 -%}
-                      {%- else -%}
-                        <details id="Details-HeaderSubMenu-{{ link.handle }}-{{ childlink.handle }}">
-                          <summary
-                            id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
-                            class="header__menu-item link link--text list-menu__item focus-inset caption-large"
-                          >
-                            <span>{{ childlink.title | escape }}</span>
-                            {{- 'icon-caret.svg' | inline_asset_content -}}
-                          </summary>
-                          <ul
-                            id="HeaderMenu-SubMenuList-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
-                            class="header__submenu list-menu motion-reduce"
-                          >
-                            {%- for grandchildlink in childlink.links -%}
-                              <li>
-                                <a
-                                  id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
-                                  href="{{ grandchildlink.url }}"
-                                  class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if grandchildlink.current %} list-menu__item--active{% endif %}"
-                                  {% if grandchildlink.current %}
-                                    aria-current="page"
-                                  {% endif %}
-                                >
-                                  {{ grandchildlink.title | escape }}
-                                </a>
-                              </li>
-                            {%- endfor -%}
-                          </ul>
-                        </details>
-                      {%- endif -%}
+                          <span>{{ childlink.title | escape }}</span>
+                          {{- 'icon-caret.svg' | inline_asset_content -}}
+                        </summary>
+                        <ul
+                          id="HeaderMenu-SubMenuList-{{ link.handle }}-{{ childlink.handle }}"
+                          class="header__submenu list-menu motion-reduce"
+                        >
+                          {%- for grandchildlink in childlink.links -%}
+                            <li>
+                              <a
+                                id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}-{{ grandchildlink.handle }}"
+                                href="{{ grandchildlink.url }}"
+                                class="header__menu-item list-menu__item link link--text focus-inset caption-large{% if grandchildlink.current %} list-menu__item--active{% endif %}"
+                                {% if grandchildlink.current %}
+                                  aria-current="page"
+                                {% endif %}
+                              >
+                                {{ grandchildlink.title | escape }}
+                              </a>
+                            </li>
+                          {%- endfor -%}
+                        </ul>
+                      </details>
                     {%- endif -%}
                   </li>
                 {%- endfor -%}
-                {%- if is_watch_parts and link.url != blank -%}
-                  <li>
-                    <a
-                      href="{{ link.url }}"
-                      class="header__menu-item list-menu__item link link--text focus-inset caption-large"
-                    >
-                      View all {{ link.title | escape }}
-                    </a>
-                  </li>
-                {%- endif -%}
               </ul>
             </details>
           </header-menu>

--- a/snippets/header-mega-menu.liquid
+++ b/snippets/header-mega-menu.liquid
@@ -35,16 +35,7 @@
                   class="mega-menu__list page-width{% if link.levels == 1 %} mega-menu__list--condensed{% endif %}"
                   role="list"
                 >
-                  {%- assign link_title_down = link.title | downcase | strip -%}
-                  {%- assign is_watch_parts = false -%}
-                  {%- if link_title_down == 'watch parts' -%}
-                    {%- assign is_watch_parts = true -%}
-                  {%- endif -%}
-                  {%- assign rendered_count = 0 -%}
                   {%- for childlink in link.links -%}
-                    {%- if is_watch_parts and rendered_count >= 5 -%}
-                      {%- continue -%}
-                    {%- endif -%}
                     <li>
                       <a
                         id="HeaderMenu-{{ link.handle }}-{{ childlink.handle }}"
@@ -56,7 +47,7 @@
                       >
                         {{ childlink.title | escape }}
                       </a>
-                      {%- if childlink.links != blank and not is_watch_parts -%}
+                      {%- if childlink.links != blank -%}
                         <ul class="list-unstyled" role="list">
                           {%- for grandchildlink in childlink.links -%}
                             <li>
@@ -74,19 +65,8 @@
                           {%- endfor -%}
                         </ul>
                       {%- endif -%}
-                      {%- assign rendered_count = rendered_count | plus: 1 -%}
                     </li>
                   {%- endfor -%}
-                  {%- if is_watch_parts and link.url != blank -%}
-                    <li>
-                      <a
-                        href="{{ link.url }}"
-                        class="mega-menu__link link"
-                      >
-                        View all {{ link.title | escape }}
-                      </a>
-                    </li>
-                  {%- endif -%}
                 </ul>
               </div>
             </details>


### PR DESCRIPTION
## Summary
- remove Watch Parts-specific overrides from the header dropdown, mega menu, and drawer snippets
- restore full reliance on the assigned navigation so menu content comes from the store configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5fe95ec483219841b237666eedda